### PR TITLE
fix the discipline issue

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
- #include <avr/pgmspace.h>
+#include <avr/pgmspace.h>
 #include "cpu.h"
 #include "hw.h"
 #include "hal.h"
@@ -835,7 +835,7 @@ static void op_retd_cb(u8_t arg0, u8_t arg1)
   sp = (sp + 3) & 0xFF;
   SET_M(x, arg0 & 0xF);
   SET_M(x + 1, (arg0 >> 4) & 0xF);
-  x = (x + 2) & 0xFFF;
+  x = ((x + 2) & 0xFF) | (XP << 8);
   call_depth--;
 }
 
@@ -854,12 +854,12 @@ static void op_halt_cb(u8_t arg0, u8_t arg1)
 
 static void op_inc_x_cb(u8_t arg0, u8_t arg1)
 {
-  x = (x + 1) & 0xFFF;
+  x = ((x + 1) & 0xFF) | (XP << 8);
 }
 
 static void op_inc_y_cb(u8_t arg0, u8_t arg1)
 {
-  y = (y + 1) & 0xFFF;
+  y = ((y + 1) & 0xFF) | (YP << 8);
 }
 
 static void op_ld_x_cb(u8_t arg0, u8_t arg1)
@@ -1029,32 +1029,32 @@ static void op_ld_mn_b_cb(u8_t arg0, u8_t arg1)
 static void op_ldpx_mx_cb(u8_t arg0, u8_t arg1)
 {
   SET_M(x, arg0);
-  x = (x + 1) & 0xFFF;
+  x = ((x + 1) & 0xFF) | (XP << 8);
 }
 
 static void op_ldpx_r_cb(u8_t arg0, u8_t arg1)
 {
   SET_RQ(arg0, RQ(arg1));
-  x = (x + 1) & 0xFFF;
+  x = ((x + 1) & 0xFF) | (XP << 8);
 }
 
 static void op_ldpy_my_cb(u8_t arg0, u8_t arg1)
 {
   SET_M(y, arg0);
-  y = (y + 1) & 0xFFF;
+  y = ((y + 1) & 0xFF) | (YP << 8);
 }
 
 static void op_ldpy_r_cb(u8_t arg0, u8_t arg1)
 {
   SET_RQ(arg0, RQ(arg1));
-  y = (y + 1) & 0xFFF;
+  y = ((y + 1) & 0xFF) | (YP << 8);
 }
 
 static void op_lbpx_cb(u8_t arg0, u8_t arg1)
 {
   SET_M(x, arg0 & 0xF);
   SET_M(x + 1, (arg0 >> 4) & 0xF);
-  x = (x + 2) & 0xFFF;
+  x = ((x + 2) & 0xFF) | (XP << 8);
 }
 
 static void op_set_cb(u8_t arg0, u8_t arg1)
@@ -1483,7 +1483,7 @@ static void op_acpx_cb(u8_t arg0, u8_t arg1)
     if (tmp >> 4) { SET_C(); } else { CLEAR_C(); }
   }
   if (!M(x)) { SET_Z(); } else { CLEAR_Z(); }
-  x = (x + 1) & 0xFFF;
+  x = ((x + 1) & 0xFF) | (XP << 8);
 }
 
 static void op_acpy_cb(u8_t arg0, u8_t arg1)
@@ -1504,7 +1504,7 @@ static void op_acpy_cb(u8_t arg0, u8_t arg1)
     if (tmp >> 4) { SET_C(); } else { CLEAR_C(); }
   }
   if (!M(y)) { SET_Z(); } else { CLEAR_Z(); }
-  y = (y + 1) & 0xFFF;
+  y = ((y + 1) & 0xFF) | (YP << 8);
 }
 
 static void op_scpx_cb(u8_t arg0, u8_t arg1)
@@ -1523,7 +1523,7 @@ static void op_scpx_cb(u8_t arg0, u8_t arg1)
   }
   if (tmp >> 4) { SET_C(); } else { CLEAR_C(); }
   if (!M(x)) { SET_Z(); } else { CLEAR_Z(); }
-  x = (x + 1) & 0xFFF;
+  x = ((x + 1) & 0xFF) | (XP << 8);
 }
 
 static void op_scpy_cb(u8_t arg0, u8_t arg1)
@@ -1542,7 +1542,7 @@ static void op_scpy_cb(u8_t arg0, u8_t arg1)
   }
   if (tmp >> 4) { SET_C(); } else { CLEAR_C(); }
   if (!M(y)) { SET_Z(); } else { CLEAR_Z(); }
-  y = (y + 1) & 0xFFF;
+  y = ((y + 1) & 0xFF) | (YP << 8);
 }
 
 static void op_not_cb(u8_t arg0, u8_t arg1)


### PR DESCRIPTION
this is a transposition of the fix: https://github.com/jcrona/tamalib/commit/08f9371f606da7195d4be19afcb072e17b6fc202 tackling an issue with the display of discipline. Here is a working example (the creature should be grounded, and the discipline should increase as a consequence):

static const uint8_t hardcodedState[] PROGMEM = {
0x85,0x01,0x22,0x00,0x03,0x02,0x00,0x00,0x01,0xE9,0x00,0xE5,0xB4,0x8F,0x16,0x00, 0x80,0x8F,0x16,0xDC,0xB4,0x8F,0x16,0x01,0x05,0x07,0x04,0x00,0x00,0x00,0xD3,0x03, 0x00,0x01,0x00,0x0C,0x00,0x00,0x00,0x0A,0x00,0x00,0x00,0x08,0x07,0x00,0x00,0x06, 0x00,0x00,0x00,0x04,0x00,0x08,0x00,0x02,0x0E,0x00,0xE0,0x20,0x18,0x00,0x00,0x00, 0x01,0x42,0xD0,0x00,0x00,0x00,0x00,0x00,0x00,0xF0,0xB0,0x00,0x00,0x00,0x08,0x1F, 0x1D,0xB3,0x80,0xD7,0x39,0x09,0xF0,0xE0,0xFB,0x00,0x00,0x01,0x70,0x0F,0x00,0x00, 0x10,0x00,0x10,0x0A,0xFF,0x50,0x02,0x11,0x00,0x13,0xAC,0x10,0xDF,0xBC,0x01,0x51, 0xC0,0x00,0xF0,0x8A,0x00,0x0F,0xFF,0x50,0x30,0x04,0x80,0x00,0x00,0x00,0x00,0x00, 0x13,0x23,0x33,0xFF,0xC1,0xC1,0xC1,0xC1,0x00,0x36,0x03,0x92,0x32,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x07,0x71,0x4B,0x17,0x71,0x77,0x17,0x71,0x77,0x1D,0x70,0x00,0x11, 0x10,0xF8,0x40,0xDD,0x04,0xAF,0xE2,0x50,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x0E,0x01,0x82,0x80,0x8C,0x8C,0x80,0x82,0x01,0x0E,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x10,0x20,0x40,0x40,0x40,0x40,0x40,0x40,0x20,0x10,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xC1,0xC3,0xDF,0xF3,0x01,0x00,0x04,0x63, 0xAE,0x46,0x30,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x90,0x41,0x23,0xC3,0xED,0x3C,0x01,0x99,0x46,0x56,0x08,0x11,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x70,0x00,0x00,0x00,0x00,0x00,0x00,0x00,};